### PR TITLE
fix: detectOS navigator undefined

### DIFF
--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -2,6 +2,9 @@ import Icon from '@/types/icon-enum';
 
 export const detectOS = (): string => {
   let osDetected;
+
+  if (typeof window === undefined) return 'other';
+
   if (navigator.userAgent.match(/Android/i)) {
     osDetected = 'android';
   } else if (navigator.userAgent.match(/BlackBerry/i)) {


### PR DESCRIPTION
Added `if (typeof window === undefined) return 'other'` to utils/common.js