### PR TITLE
refactor: extract TextInput from Input component

### DIFF
--- a/src/components/input-icon/index.tsx
+++ b/src/components/input-icon/index.tsx
@@ -1,7 +1,7 @@
 import { clsx } from 'clsx';
 import Image from 'next/image';
 
-export type TextInputIconProps = {
+export type InputIconProps = {
   src: string;
   alt: string;
   hasDividerLine?: boolean;
@@ -9,7 +9,7 @@ export type TextInputIconProps = {
   onClick?: () => void;
 };
 
-export default function TextInputIcon(props: TextInputIconProps) {
+export default function InputIcon(props: InputIconProps) {
   const { src, alt, hasDividerLine, onClick, position } = props;
 
   const iconImgClass = clsx(

--- a/src/components/input-icon/index.tsx
+++ b/src/components/input-icon/index.tsx
@@ -13,16 +13,16 @@ export default function InputIcon(props: InputIconProps) {
   const { src, alt, hasDividerLine, onClick, position } = props;
 
   const iconImgClass = clsx(
-    'mx-[8px] h-auto w-auto',
+    'mx-2 h-auto w-auto',
     !hasDividerLine && (position === 'left' ? 'ms-[12px]' : 'me-[12px]'),
-    onClick && 'rounded-full p-[4px] hover:cursor-pointer hover:bg-[#ccc] active:bg-[#ccc]',
+    onClick && 'rounded-full p-1 hover:cursor-pointer hover:bg-[#ccc] active:bg-[#ccc]',
   );
 
   return (
-    <div onClick={onClick} className='flex h-[100%] items-center'>
-      {hasDividerLine && position === 'right' && <div className='h-[60%] w-[1px] bg-[#6969694d]'></div>}
+    <div onClick={onClick} className='flex h-full items-center'>
+      {hasDividerLine && position === 'right' && <div className='h-3/5 w-px bg-[#6969694d]'></div>}
       <Image src={src} alt={alt} width={0} height={0} className={iconImgClass} />
-      {hasDividerLine && position === 'left' && <div className='h-[60%] w-[1px] bg-[#6969694d]'></div>}
+      {hasDividerLine && position === 'left' && <div className='h-3/5 w-px bg-[#6969694d]'></div>}
     </div>
   );
 }

--- a/src/components/input-icon/index.tsx
+++ b/src/components/input-icon/index.tsx
@@ -20,9 +20,9 @@ export default function InputIcon(props: InputIconProps) {
 
   return (
     <div onClick={onClick} className='flex h-full items-center'>
-      {hasDividerLine && position === 'right' && <div className='h-3/5 w-px bg-[#6969694d]'></div>}
+      {hasDividerLine && position === 'right' && <div className='h-full w-px bg-[#6969694d]'></div>}
       <Image src={src} alt={alt} width={0} height={0} className={iconImgClass} />
-      {hasDividerLine && position === 'left' && <div className='h-3/5 w-px bg-[#6969694d]'></div>}
+      {hasDividerLine && position === 'left' && <div className='h-full w-px bg-[#6969694d]'></div>}
     </div>
   );
 }

--- a/src/components/input-icon/index.tsx
+++ b/src/components/input-icon/index.tsx
@@ -14,7 +14,7 @@ export default function InputIcon(props: InputIconProps) {
 
   const iconImgClass = clsx(
     'mx-2 h-auto w-auto',
-    !hasDividerLine && (position === 'left' ? 'ms-[12px]' : 'me-[12px]'),
+    !hasDividerLine && (position === 'left' ? 'ms-3' : 'me-3'),
     onClick && 'rounded-full p-1 hover:cursor-pointer hover:bg-[#ccc] active:bg-[#ccc]',
   );
 

--- a/src/components/text-input/index.tsx
+++ b/src/components/text-input/index.tsx
@@ -1,0 +1,71 @@
+import clsx from 'clsx';
+import { useMemo } from 'react';
+
+import InputIcon, { TextInputIconProps } from './input-icon';
+
+type TextInputProps = {
+  value: string;
+  onInput: (value: string) => void;
+  onEnterKey?: () => void;
+  placeholder?: string;
+  fontSize?: number;
+  isDisabled?: boolean;
+  type?: string;
+  className?: string;
+  leftIconProps?: Omit<TextInputIconProps, 'position'>;
+  rightIconProps?: Omit<TextInputIconProps, 'position'>;
+  tabIndex?: number;
+  isAutoFocus?: boolean;
+};
+
+export default function TextInput({
+  value,
+  onInput,
+  onEnterKey,
+  placeholder,
+  fontSize = 16,
+  isDisabled,
+  type,
+  className,
+  leftIconProps,
+  rightIconProps,
+  tabIndex,
+  isAutoFocus,
+}: TextInputProps) {
+  const containerClass = useMemo(
+    () =>
+      clsx(
+        'flex w-[100%] relative items-center rounded-[8px] border-[0.5px] border-solid border-[#7e7e7e4d] text-black focus-within:border-[1px] focus-within:border-primary',
+        isDisabled && 'bg-primary/[.2] text-primary',
+        className,
+      ),
+    [isDisabled, className],
+  );
+
+  const inputClass = useMemo(
+    () => clsx('mx-[8px] flex-grow px-[4px] outline-none placeholder:text-royal-300', isDisabled && 'bg-transparent'),
+    [isDisabled],
+  );
+
+  return (
+    <div className={containerClass} style={{ height: `${fontSize * 1.5 + 26}px` }}>
+      {leftIconProps && <InputIcon {...leftIconProps} position='left' />}
+      <input
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && onEnterKey) onEnterKey();
+        }}
+        value={value}
+        onInput={(e) => onInput(e.currentTarget.value)}
+        className={inputClass}
+        style={{ fontSize: `${fontSize}px` }}
+        placeholder={placeholder}
+        type={type}
+        disabled={isDisabled}
+        size={1}
+        tabIndex={tabIndex}
+        autoFocus={isAutoFocus}
+      />
+      {rightIconProps && <InputIcon {...rightIconProps} position='right' />}
+    </div>
+  );
+}

--- a/src/components/text-input/index.tsx
+++ b/src/components/text-input/index.tsx
@@ -41,7 +41,7 @@ export default function TextInput({
   );
 
   const inputClass = useMemo(
-    () => clsx('mx-[8px] flex-grow px-[4px] outline-none placeholder:text-royal-300', isDisabled && 'bg-transparent'),
+    () => clsx('mx-2 flex-grow px-1 outline-none placeholder:text-royal-300', isDisabled && 'bg-transparent'),
     [isDisabled],
   );
 

--- a/src/components/text-input/index.tsx
+++ b/src/components/text-input/index.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import { useMemo } from 'react';
 
-import InputIcon, { TextInputIconProps } from './input-icon';
+import InputIcon, { InputIconProps } from '../input-icon';
 
 type TextInputProps = {
   value: string;
@@ -12,8 +12,8 @@ type TextInputProps = {
   isDisabled?: boolean;
   type?: string;
   className?: string;
-  leftIconProps?: Omit<TextInputIconProps, 'position'>;
-  rightIconProps?: Omit<TextInputIconProps, 'position'>;
+  leftIconProps?: Omit<InputIconProps, 'position'>;
+  rightIconProps?: Omit<InputIconProps, 'position'>;
   tabIndex?: number;
   isAutoFocus?: boolean;
 };

--- a/src/components/text-input/index.tsx
+++ b/src/components/text-input/index.tsx
@@ -5,8 +5,6 @@ import InputIcon, { InputIconProps } from '../input-icon';
 
 type TextInputProps = {
   value: string;
-  onInput: (value: string) => void;
-  onEnterKey?: () => void;
   placeholder?: string;
   isDisabled?: boolean;
   type?: string;
@@ -15,12 +13,12 @@ type TextInputProps = {
   rightIconProps?: Omit<InputIconProps, 'position'>;
   tabIndex?: number;
   isAutoFocus?: boolean;
+  onInput: (value: string) => void;
+  onEnterKey?: () => void;
 };
 
 export default function TextInput({
   value,
-  onInput,
-  onEnterKey,
   placeholder,
   isDisabled,
   type,
@@ -29,11 +27,13 @@ export default function TextInput({
   rightIconProps,
   tabIndex,
   isAutoFocus,
+  onInput,
+  onEnterKey,
 }: TextInputProps) {
   const containerClass = useMemo(
     () =>
       clsx(
-        'flex w-[100%] py-2 relative items-center rounded-[8px] border-[0.5px] border-solid border-[#7e7e7e4d] text-black focus-within:border-[1px] focus-within:border-primary',
+        'flex w-full py-2 relative items-center rounded-lg border-[0.5px] border-solid border-[#7e7e7e4d] text-black focus-within:border focus-within:border-primary',
         isDisabled && 'bg-primary/[.2] text-primary',
         className,
       ),

--- a/src/components/text-input/index.tsx
+++ b/src/components/text-input/index.tsx
@@ -33,7 +33,7 @@ export default function TextInput({
   const containerClass = useMemo(
     () =>
       clsx(
-        'flex w-full py-2 relative items-center rounded-lg border-[0.5px] border-solid border-[#7e7e7e4d] text-black focus-within:border focus-within:border-primary',
+        'flex h-[42px] w-full py-2 relative items-center rounded-lg border-[0.5px] border-solid border-[#7e7e7e4d] text-black focus-within:border focus-within:border-primary',
         isDisabled && 'bg-primary/[.2] text-primary',
         className,
       ),

--- a/src/components/text-input/index.tsx
+++ b/src/components/text-input/index.tsx
@@ -8,7 +8,6 @@ type TextInputProps = {
   onInput: (value: string) => void;
   onEnterKey?: () => void;
   placeholder?: string;
-  fontSize?: number;
   isDisabled?: boolean;
   type?: string;
   className?: string;
@@ -23,7 +22,6 @@ export default function TextInput({
   onInput,
   onEnterKey,
   placeholder,
-  fontSize = 16,
   isDisabled,
   type,
   className,
@@ -35,7 +33,7 @@ export default function TextInput({
   const containerClass = useMemo(
     () =>
       clsx(
-        'flex w-[100%] relative items-center rounded-[8px] border-[0.5px] border-solid border-[#7e7e7e4d] text-black focus-within:border-[1px] focus-within:border-primary',
+        'flex w-[100%] py-2 relative items-center rounded-[8px] border-[0.5px] border-solid border-[#7e7e7e4d] text-black focus-within:border-[1px] focus-within:border-primary',
         isDisabled && 'bg-primary/[.2] text-primary',
         className,
       ),
@@ -48,7 +46,7 @@ export default function TextInput({
   );
 
   return (
-    <div className={containerClass} style={{ height: `${fontSize * 1.5 + 26}px` }}>
+    <div className={containerClass}>
       {leftIconProps && <InputIcon {...leftIconProps} position='left' />}
       <input
         onKeyDown={(e) => {
@@ -57,7 +55,6 @@ export default function TextInput({
         value={value}
         onInput={(e) => onInput(e.currentTarget.value)}
         className={inputClass}
-        style={{ fontSize: `${fontSize}px` }}
         placeholder={placeholder}
         type={type}
         disabled={isDisabled}

--- a/src/components/text-input/input-icon/index.tsx
+++ b/src/components/text-input/input-icon/index.tsx
@@ -1,0 +1,28 @@
+import { clsx } from 'clsx';
+import Image from 'next/image';
+
+export type TextInputIconProps = {
+  src: string;
+  alt: string;
+  hasDividerLine?: boolean;
+  position: 'left' | 'right';
+  onClick?: () => void;
+};
+
+export default function TextInputIcon(props: TextInputIconProps) {
+  const { src, alt, hasDividerLine, onClick, position } = props;
+
+  const iconImgClass = clsx(
+    'mx-[8px] h-auto w-auto',
+    !hasDividerLine && (position === 'left' ? 'ms-[12px]' : 'me-[12px]'),
+    onClick && 'rounded-full p-[4px] hover:cursor-pointer hover:bg-[#ccc] active:bg-[#ccc]',
+  );
+
+  return (
+    <div onClick={onClick} className='flex h-[100%] items-center'>
+      {hasDividerLine && position === 'right' && <div className='h-[60%] w-[1px] bg-[#6969694d]'></div>}
+      <Image src={src} alt={alt} width={0} height={0} className={iconImgClass} />
+      {hasDividerLine && position === 'left' && <div className='h-[60%] w-[1px] bg-[#6969694d]'></div>}
+    </div>
+  );
+}


### PR DESCRIPTION
Creating a `TextInput` component that is less complicated than the `Input` component, which was originally the combination of `TextInput` and `SelectInput`

**_BREAKING CHANGE:_** Removing the original Input component requires updating the usage of such component accordingly. Currently, the `Input` component and places using it remain untouched.